### PR TITLE
Env Components

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@mujo/plugins",
-  "version": "0.0.1",
+  "version": "0.0.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -121,20 +121,6 @@
         "@babel/helper-hoist-variables": "^7.4.4",
         "@babel/traverse": "^7.4.4",
         "@babel/types": "^7.4.4"
-      }
-    },
-    "@babel/helper-create-class-features-plugin": {
-      "version": "7.5.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.5.5.tgz",
-      "integrity": "sha512-ZsxkyYiRA7Bg+ZTRpPvB6AbOFKTFFK4LrvTet8lInm0V468MWCaSYJE+I7v2z2r8KNLtYiV+K5kTCnR7dvyZjg==",
-      "dev": true,
-      "requires": {
-        "@babel/helper-function-name": "^7.1.0",
-        "@babel/helper-member-expression-to-functions": "^7.5.5",
-        "@babel/helper-optimise-call-expression": "^7.0.0",
-        "@babel/helper-plugin-utils": "^7.0.0",
-        "@babel/helper-replace-supers": "^7.5.5",
-        "@babel/helper-split-export-declaration": "^7.4.4"
       }
     },
     "@babel/helper-define-map": {
@@ -338,27 +324,6 @@
         "@babel/plugin-syntax-async-generators": "^7.2.0"
       }
     },
-    "@babel/plugin-proposal-class-properties": {
-      "version": "7.5.5",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.5.5.tgz",
-      "integrity": "sha512-AF79FsnWFxjlaosgdi421vmYG6/jg79bVD0dpD44QdgobzHKuLZ6S3vl8la9qIeSwGi8i1fS0O1mfuDAAdo1/A==",
-      "dev": true,
-      "requires": {
-        "@babel/helper-create-class-features-plugin": "^7.5.5",
-        "@babel/helper-plugin-utils": "^7.0.0"
-      }
-    },
-    "@babel/plugin-proposal-decorators": {
-      "version": "7.4.4",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-decorators/-/plugin-proposal-decorators-7.4.4.tgz",
-      "integrity": "sha512-z7MpQz3XC/iQJWXH9y+MaWcLPNSMY9RQSthrLzak8R8hCj0fuyNk+Dzi9kfNe/JxxlWQ2g7wkABbgWjW36MTcw==",
-      "dev": true,
-      "requires": {
-        "@babel/helper-create-class-features-plugin": "^7.4.4",
-        "@babel/helper-plugin-utils": "^7.0.0",
-        "@babel/plugin-syntax-decorators": "^7.2.0"
-      }
-    },
     "@babel/plugin-proposal-dynamic-import": {
       "version": "7.5.0",
       "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-dynamic-import/-/plugin-proposal-dynamic-import-7.5.0.tgz",
@@ -419,28 +384,10 @@
         "@babel/helper-plugin-utils": "^7.0.0"
       }
     },
-    "@babel/plugin-syntax-decorators": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-decorators/-/plugin-syntax-decorators-7.2.0.tgz",
-      "integrity": "sha512-38QdqVoXdHUQfTpZo3rQwqQdWtCn5tMv4uV6r2RMfTqNBuv4ZBhz79SfaQWKTVmxHjeFv/DnXVC/+agHCklYWA==",
-      "dev": true,
-      "requires": {
-        "@babel/helper-plugin-utils": "^7.0.0"
-      }
-    },
     "@babel/plugin-syntax-dynamic-import": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-dynamic-import/-/plugin-syntax-dynamic-import-7.2.0.tgz",
       "integrity": "sha512-mVxuJ0YroI/h/tbFTPGZR8cv6ai+STMKNBq0f8hFxsxWjl94qqhsb+wXbpNMDPU3cfR1TIsVFzU3nXyZMqyK4w==",
-      "dev": true,
-      "requires": {
-        "@babel/helper-plugin-utils": "^7.0.0"
-      }
-    },
-    "@babel/plugin-syntax-flow": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-flow/-/plugin-syntax-flow-7.2.0.tgz",
-      "integrity": "sha512-r6YMuZDWLtLlu0kqIim5o/3TNRAlWb073HwT3e2nKf9I8IIvOggPrnILYPsrrKilmn/mYEMCf/Z07w3yQJF6dg==",
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0"
@@ -477,15 +424,6 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.2.0.tgz",
       "integrity": "sha512-bDe4xKNhb0LI7IvZHiA13kff0KEfaGX/Hv4lMA9+7TEc63hMNvfKo6ZFpXhKuEp+II/q35Gc4NoMeDZyaUbj9w==",
-      "dev": true,
-      "requires": {
-        "@babel/helper-plugin-utils": "^7.0.0"
-      }
-    },
-    "@babel/plugin-syntax-typescript": {
-      "version": "7.3.3",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.3.3.tgz",
-      "integrity": "sha512-dGwbSMA1YhVS8+31CnPR7LB4pcbrzcV99wQzby4uAfrkZPYZlQ7ImwdpzLqi6Z6IL02b8IAL379CaMwo0x5Lag==",
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0"
@@ -594,16 +532,6 @@
         "@babel/helper-plugin-utils": "^7.0.0"
       }
     },
-    "@babel/plugin-transform-flow-strip-types": {
-      "version": "7.4.4",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-flow-strip-types/-/plugin-transform-flow-strip-types-7.4.4.tgz",
-      "integrity": "sha512-WyVedfeEIILYEaWGAUWzVNyqG4sfsNooMhXWsu/YzOvVGcsnPb5PguysjJqI3t3qiaYj0BR8T2f5njdjTGe44Q==",
-      "dev": true,
-      "requires": {
-        "@babel/helper-plugin-utils": "^7.0.0",
-        "@babel/plugin-syntax-flow": "^7.2.0"
-      }
-    },
     "@babel/plugin-transform-for-of": {
       "version": "7.4.4",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.4.4.tgz",
@@ -653,9 +581,9 @@
       }
     },
     "@babel/plugin-transform-modules-commonjs": {
-      "version": "7.5.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.5.0.tgz",
-      "integrity": "sha512-xmHq0B+ytyrWJvQTc5OWAC4ii6Dhr0s22STOoydokG51JjWhyYo5mRPXoi+ZmtHQhZZwuXNN+GG5jy5UZZJxIQ==",
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.6.0.tgz",
+      "integrity": "sha512-Ma93Ix95PNSEngqomy5LSBMAQvYKVe3dy+JlVJSHEXZR5ASL9lQBedMiCyVtmTLraIDVRE3ZjTZvmXXD2Ozw3g==",
       "dev": true,
       "requires": {
         "@babel/helper-module-transforms": "^7.4.4",
@@ -791,18 +719,6 @@
         "@babel/helper-plugin-utils": "^7.0.0"
       }
     },
-    "@babel/plugin-transform-runtime": {
-      "version": "7.5.5",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.5.5.tgz",
-      "integrity": "sha512-6Xmeidsun5rkwnGfMOp6/z9nSzWpHFNVr2Jx7kwoq4mVatQfQx5S56drBgEHF+XQbKOdIaOiMIINvp/kAwMN+w==",
-      "dev": true,
-      "requires": {
-        "@babel/helper-module-imports": "^7.0.0",
-        "@babel/helper-plugin-utils": "^7.0.0",
-        "resolve": "^1.8.1",
-        "semver": "^5.5.1"
-      }
-    },
     "@babel/plugin-transform-shorthand-properties": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.2.0.tgz",
@@ -848,17 +764,6 @@
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0"
-      }
-    },
-    "@babel/plugin-transform-typescript": {
-      "version": "7.5.5",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.5.5.tgz",
-      "integrity": "sha512-pehKf4m640myZu5B2ZviLaiBlxMCjSZ1qTEO459AXKX5GnPueyulJeCqZFs1nz/Ya2dDzXQ1NxZ/kKNWyD4h6w==",
-      "dev": true,
-      "requires": {
-        "@babel/helper-create-class-features-plugin": "^7.5.5",
-        "@babel/helper-plugin-utils": "^7.0.0",
-        "@babel/plugin-syntax-typescript": "^7.2.0"
       }
     },
     "@babel/plugin-transform-unicode-regex": {
@@ -943,20 +848,10 @@
         "@babel/plugin-transform-react-jsx-source": "^7.0.0"
       }
     },
-    "@babel/preset-typescript": {
-      "version": "7.3.3",
-      "resolved": "https://registry.npmjs.org/@babel/preset-typescript/-/preset-typescript-7.3.3.tgz",
-      "integrity": "sha512-mzMVuIP4lqtn4du2ynEfdO0+RYcslwrZiJHXu4MGaC1ctJiW2fyaeDrtjJGs7R/KebZ1sgowcIoWf4uRpEfKEg==",
-      "dev": true,
-      "requires": {
-        "@babel/helper-plugin-utils": "^7.0.0",
-        "@babel/plugin-transform-typescript": "^7.3.2"
-      }
-    },
     "@babel/runtime": {
-      "version": "7.5.5",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.5.5.tgz",
-      "integrity": "sha512-28QvEGyQyNkB0/m2B4FU7IEZGK2NUrcMtT6BZEFALTguLk+AUT6ofsHtPk5QyjAdUkpMJ+/Em+quwz4HOt30AQ==",
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.6.0.tgz",
+      "integrity": "sha512-89eSBLJsxNxOERC0Op4vd+0Bqm6wRMqMbFtV3i0/fbaWw/mJ8Q3eBvgX0G4SyrOOLCtbu98HspF8o09MRT+KzQ==",
       "dev": true,
       "requires": {
         "regenerator-runtime": "^0.13.2"
@@ -1366,7 +1261,8 @@
     "@mujo/ingress": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/@mujo/ingress/-/ingress-0.1.0.tgz",
-      "integrity": "sha512-OfiVoKhHx/HwgD3zNF0PtJlGykkA2uXmJm1yFlXA0FzqdbSs35wyGwVuVky4fDciAW5dn4zONfjxXvh1LyW1sA=="
+      "integrity": "sha512-OfiVoKhHx/HwgD3zNF0PtJlGykkA2uXmJm1yFlXA0FzqdbSs35wyGwVuVky4fDciAW5dn4zONfjxXvh1LyW1sA==",
+      "dev": true
     },
     "@types/babel__core": {
       "version": "7.1.2",
@@ -1829,12 +1725,6 @@
       "integrity": "sha1-CvMqmm4Tyno/1QaeYtew9Y0NiUY=",
       "dev": true
     },
-    "babel-plugin-transform-react-remove-prop-types": {
-      "version": "0.4.24",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-react-remove-prop-types/-/babel-plugin-transform-react-remove-prop-types-0.4.24.tgz",
-      "integrity": "sha512-eqj0hVcJUR57/Ug2zE1Yswsw4LhuqqHhD+8v120T1cl3kjg76QwtyBrdIk4WVwK+lAhBJVYCd/v+4nc4y+8JsA==",
-      "dev": true
-    },
     "babel-plugin-transform-runtime": {
       "version": "6.23.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-runtime/-/babel-plugin-transform-runtime-6.23.0.tgz",
@@ -1852,30 +1742,6 @@
       "requires": {
         "@babel/plugin-syntax-object-rest-spread": "^7.0.0",
         "babel-plugin-jest-hoist": "^24.9.0"
-      }
-    },
-    "babel-preset-react-app": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/babel-preset-react-app/-/babel-preset-react-app-9.0.1.tgz",
-      "integrity": "sha512-v7MeY+QxdBhM9oU5uOQCIHLsErYkEbbjctXsb10II+KAnttbe0rvprvP785dRxfa9dI4ZbsGXsRU07Qdi5BtOw==",
-      "dev": true,
-      "requires": {
-        "@babel/core": "7.5.5",
-        "@babel/plugin-proposal-class-properties": "7.5.5",
-        "@babel/plugin-proposal-decorators": "7.4.4",
-        "@babel/plugin-proposal-object-rest-spread": "7.5.5",
-        "@babel/plugin-syntax-dynamic-import": "7.2.0",
-        "@babel/plugin-transform-destructuring": "7.5.0",
-        "@babel/plugin-transform-flow-strip-types": "7.4.4",
-        "@babel/plugin-transform-react-display-name": "7.2.0",
-        "@babel/plugin-transform-runtime": "7.5.5",
-        "@babel/preset-env": "7.5.5",
-        "@babel/preset-react": "7.0.0",
-        "@babel/preset-typescript": "7.3.3",
-        "@babel/runtime": "7.5.5",
-        "babel-plugin-dynamic-import-node": "2.3.0",
-        "babel-plugin-macros": "2.6.1",
-        "babel-plugin-transform-react-remove-prop-types": "0.4.24"
       }
     },
     "babel-runtime": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1363,6 +1363,11 @@
         "prettier": "^1.18.2"
       }
     },
+    "@mujo/ingress": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@mujo/ingress/-/ingress-0.1.0.tgz",
+      "integrity": "sha512-OfiVoKhHx/HwgD3zNF0PtJlGykkA2uXmJm1yFlXA0FzqdbSs35wyGwVuVky4fDciAW5dn4zONfjxXvh1LyW1sA=="
+    },
     "@types/babel__core": {
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.2.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@mujo/plugins",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1264,6 +1264,37 @@
       "integrity": "sha512-OfiVoKhHx/HwgD3zNF0PtJlGykkA2uXmJm1yFlXA0FzqdbSs35wyGwVuVky4fDciAW5dn4zONfjxXvh1LyW1sA==",
       "dev": true
     },
+    "@sheerun/mutationobserver-shim": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@sheerun/mutationobserver-shim/-/mutationobserver-shim-0.3.2.tgz",
+      "integrity": "sha512-vTCdPp/T/Q3oSqwHmZ5Kpa9oI7iLtGl3RQaA/NyLHikvcrPxACkkKVr/XzkSPJWXHRhKGzVvb0urJsbMlRxi1Q==",
+      "dev": true
+    },
+    "@testing-library/dom": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-6.2.0.tgz",
+      "integrity": "sha512-YaaoAIDTNV8AfC19XLa6KNeBB5KuSxWYPrgYN1vBu1i+czQlfWJSCS0A3yd2V3BUH9di9C1BD+7OoyVBpZCh2Q==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.5.5",
+        "@sheerun/mutationobserver-shim": "^0.3.2",
+        "@types/testing-library__dom": "^6.0.0",
+        "aria-query": "3.0.0",
+        "pretty-format": "^24.8.0",
+        "wait-for-expect": "^1.3.0"
+      }
+    },
+    "@testing-library/react": {
+      "version": "9.1.4",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-9.1.4.tgz",
+      "integrity": "sha512-fQ/PXZoLcmnS1W5ZiM3P7XBy2x6Hm9cJAT/ZDuZKzJ1fS1rN3j31p7ReAqUe3N1kJ46sNot0n1oiGbz7FPU+FA==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.5.5",
+        "@testing-library/dom": "^6.1.0",
+        "@types/testing-library__react": "^9.1.0"
+      }
+    },
     "@types/babel__core": {
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.2.tgz",
@@ -1330,11 +1361,55 @@
         "@types/istanbul-lib-report": "*"
       }
     },
+    "@types/prop-types": {
+      "version": "15.7.2",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.2.tgz",
+      "integrity": "sha512-f8JzJNWVhKtc9dg/dyDNfliTKNOJSLa7Oht/ElZdF/UbMUmAH3rLmAk3ODNjw0mZajDEgatA03tRjB4+Dp/tzA==",
+      "dev": true
+    },
+    "@types/react": {
+      "version": "16.9.2",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-16.9.2.tgz",
+      "integrity": "sha512-jYP2LWwlh+FTqGd9v7ynUKZzjj98T8x7Yclz479QdRhHfuW9yQ+0jjnD31eXSXutmBpppj5PYNLYLRfnZJvcfg==",
+      "dev": true,
+      "requires": {
+        "@types/prop-types": "*",
+        "csstype": "^2.2.0"
+      }
+    },
+    "@types/react-dom": {
+      "version": "16.9.0",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-16.9.0.tgz",
+      "integrity": "sha512-OL2lk7LYGjxn4b0efW3Pvf2KBVP0y1v3wip1Bp7nA79NkOpElH98q3WdCEdDj93b2b0zaeBG9DvriuKjIK5xDA==",
+      "dev": true,
+      "requires": {
+        "@types/react": "*"
+      }
+    },
     "@types/stack-utils": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-1.0.1.tgz",
       "integrity": "sha512-l42BggppR6zLmpfU6fq9HEa2oGPEI8yrSPL3GITjfRInppYFahObbIQOQK3UGxEnyQpltZLaPe75046NOZQikw==",
       "dev": true
+    },
+    "@types/testing-library__dom": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/@types/testing-library__dom/-/testing-library__dom-6.0.3.tgz",
+      "integrity": "sha512-NCjixGZ6iubYpe63YKYJy/bDkPp+HD8fbi+0iXcaYhsYjQhoa7IfFz/WcaCRZJnKSi63c9GSK9pZi/Y8/gTvFA==",
+      "dev": true,
+      "requires": {
+        "pretty-format": "^24.3.0"
+      }
+    },
+    "@types/testing-library__react": {
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/@types/testing-library__react/-/testing-library__react-9.1.1.tgz",
+      "integrity": "sha512-8/toTJaIlS3BC7JrK2ElTnbjH8tmFP7atdL2ZsIa1JDmH9RKSm/7Wp5oMDJzXoWr988Mv7ym/XZ8LRglyoGCGw==",
+      "dev": true,
+      "requires": {
+        "@types/react-dom": "*",
+        "@types/testing-library__dom": "*"
+      }
     },
     "@types/yargs": {
       "version": "13.0.2",
@@ -6194,6 +6269,18 @@
         "prop-types": "^15.6.2"
       }
     },
+    "react-dom": {
+      "version": "16.9.0",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.9.0.tgz",
+      "integrity": "sha512-YFT2rxO9hM70ewk9jq0y6sQk8cL02xm4+IzYBz75CQGlClQQ1Bxq0nhHF6OtSbit+AIahujJgb/CPRibFkMNJQ==",
+      "dev": true,
+      "requires": {
+        "loose-envify": "^1.1.0",
+        "object-assign": "^4.1.1",
+        "prop-types": "^15.6.2",
+        "scheduler": "^0.15.0"
+      }
+    },
     "react-is": {
       "version": "16.9.0",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.9.0.tgz",
@@ -7538,6 +7625,12 @@
         "webidl-conversions": "^4.0.2",
         "xml-name-validator": "^3.0.0"
       }
+    },
+    "wait-for-expect": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/wait-for-expect/-/wait-for-expect-1.3.0.tgz",
+      "integrity": "sha512-8fJU7jiA96HfGPt+P/UilelSAZfhMBJ52YhKzlmZQvKEZU2EcD1GQ0yqGB6liLdHjYtYAoGVigYwdxr5rktvzA==",
+      "dev": true
     },
     "walker": {
       "version": "1.0.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mujo/plugins",
-  "version": "0.0.2",
+  "version": "0.0.6",
   "description": "A set of utilities to create plugins in Mujo",
   "main": "dist/index.js",
   "repository": {
@@ -9,6 +9,9 @@
   },
   "keywords": [
     "react"
+  ],
+  "files": [
+    "dist/**/*"
   ],
   "author": "Jacob Lowe",
   "license": "ISC",
@@ -27,11 +30,11 @@
     "@babel/core": "^7.4.5",
     "@babel/preset-env": "^7.4.5",
     "@babel/preset-react": "^7.0.0",
+    "@babel/runtime": "^7.6.0",
     "@emotion/core": "^10.0.14",
     "@mujo/eslint-config": "^1.0.4",
     "@mujo/ingress": "^0.1.0",
     "babel-plugin-transform-runtime": "^6.23.0",
-    "babel-preset-react-app": "^9.0.1",
     "eslint": "^5.16.0",
     "jest": "^24.9.0",
     "jest-environment-jsdom-fourteen": "0.1.0",
@@ -79,7 +82,11 @@
   },
   "babel": {
     "presets": [
-      "react-app"
+      "@babel/preset-env",
+      "@babel/preset-react"
     ]
-  }
+  },
+  "browserslist": [
+    "last 3 Chrome versions"
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "@emotion/core": "^10.0.14",
     "@mujo/eslint-config": "^1.0.4",
     "@mujo/ingress": "^0.1.0",
+    "@testing-library/react": "^9.1.4",
     "babel-plugin-transform-runtime": "^6.23.0",
     "eslint": "^5.16.0",
     "jest": "^24.9.0",
@@ -43,6 +44,7 @@
     "jest-watch-typeahead": "^0.3.1",
     "prettier": "^1.17.1",
     "react": "^16.9.0",
+    "react-dom": "^16.9.0",
     "react-test-renderer": "^16.9.0"
   },
   "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mujo/plugins",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "A set of utilities to create plugins in Mujo",
   "main": "dist/index.js",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@mujo/plugins",
   "version": "0.0.1",
   "description": "A set of utilities to create plugins in Mujo",
-  "main": "index.js",
+  "main": "dist/index.js",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/mujo-code/plugins.git"
@@ -29,6 +29,7 @@
     "@babel/preset-react": "^7.0.0",
     "@emotion/core": "^10.0.14",
     "@mujo/eslint-config": "^1.0.4",
+    "@mujo/ingress": "^0.1.0",
     "babel-plugin-transform-runtime": "^6.23.0",
     "babel-preset-react-app": "^9.0.1",
     "eslint": "^5.16.0",
@@ -43,7 +44,8 @@
   },
   "peerDependencies": {
     "@emotion/core": ">=10.0.14",
-    "react": ">=16.8.6"
+    "react": ">=16.8.6",
+    "@mujo/ingress": ">=0.1.0"
   },
   "jest": {
     "collectCoverageFrom": [

--- a/src/components/background.js
+++ b/src/components/background.js
@@ -1,0 +1,10 @@
+import React, { useContext } from 'react'
+import { context } from './plugin-provider'
+
+export const Background = ({ children }) => {
+  const { env } = useContext(context)
+  if (env === 'background') {
+    return <>{children}</>
+  }
+  return null
+}

--- a/src/components/background.test.js
+++ b/src/components/background.test.js
@@ -1,0 +1,32 @@
+import React from 'react'
+import { create } from 'react-test-renderer'
+import { Background } from './background'
+import { PluginProvider } from './plugin-provider'
+
+describe('Background component', () => {
+  test('Background renders children when env is set to background', () => {
+    const Foo = jest.fn().mockReturnValue(null)
+    const { root } = create(
+      <PluginProvider env="background">
+        <Background>
+          <Foo />
+        </Background>
+      </PluginProvider>
+    )
+
+    expect(root.findByType(Foo)).toBeTruthy()
+  })
+
+  test('Background does not render children when env is not background', () => {
+    const Foo = jest.fn().mockReturnValue(null)
+    const { root } = create(
+      <PluginProvider env="ntp">
+        <Background>
+          <Foo />
+        </Background>
+      </PluginProvider>
+    )
+
+    expect(() => root.findByType(Foo)).toThrow()
+  })
+})

--- a/src/components/content.js
+++ b/src/components/content.js
@@ -1,0 +1,10 @@
+import React, { useContext } from 'react'
+import { context } from './plugin-provider'
+
+export const Content = ({ children }) => {
+  const { env } = useContext(context)
+  if (env === 'content') {
+    return <>{children}</>
+  }
+  return null
+}

--- a/src/components/content.test.js
+++ b/src/components/content.test.js
@@ -1,0 +1,32 @@
+import React from 'react'
+import { create } from 'react-test-renderer'
+import { Content } from './content'
+import { PluginProvider } from './plugin-provider'
+
+describe('Content component', () => {
+  test('Content renders children when env is set to content', () => {
+    const Foo = jest.fn().mockReturnValue(null)
+    const { root } = create(
+      <PluginProvider env="content">
+        <Content>
+          <Foo />
+        </Content>
+      </PluginProvider>
+    )
+
+    expect(root.findByType(Foo)).toBeTruthy()
+  })
+
+  test('Content does not render children when env is not content', () => {
+    const Foo = jest.fn().mockReturnValue(null)
+    const { root } = create(
+      <PluginProvider env="background">
+        <Content>
+          <Foo />
+        </Content>
+      </PluginProvider>
+    )
+
+    expect(() => root.findByType(Foo)).toThrow()
+  })
+})

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -1,2 +1,5 @@
-export * from './plugin-provider'
 export * from './tab'
+export * from './background'
+export * from './content'
+export * from './plugin-provider'
+export * from './new-tab-page'

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -1,0 +1,2 @@
+export * from './plugin-provider'
+export * from './tab'

--- a/src/components/new-tab-page.js
+++ b/src/components/new-tab-page.js
@@ -1,0 +1,10 @@
+import React, { useContext } from 'react'
+import { context } from './plugin-provider'
+
+export const NewTabPage = ({ children }) => {
+  const { env } = useContext(context)
+  if (env === 'ntp') {
+    return <>{children}</>
+  }
+  return null
+}

--- a/src/components/new-tab-page.test.js
+++ b/src/components/new-tab-page.test.js
@@ -1,0 +1,32 @@
+import React from 'react'
+import { create } from 'react-test-renderer'
+import { NewTabPage } from './new-tab-page'
+import { PluginProvider } from './plugin-provider'
+
+describe('NewTabPage component', () => {
+  test('NewTabPage renders children when env is set to ntp', () => {
+    const Foo = jest.fn().mockReturnValue(null)
+    const { root } = create(
+      <PluginProvider env="ntp">
+        <NewTabPage>
+          <Foo />
+        </NewTabPage>
+      </PluginProvider>
+    )
+
+    expect(root.findByType(Foo)).toBeTruthy()
+  })
+
+  test('NewTabPage does not render children when env is not ntp', () => {
+    const Foo = jest.fn().mockReturnValue(null)
+    const { root } = create(
+      <PluginProvider env="background">
+        <NewTabPage>
+          <Foo />
+        </NewTabPage>
+      </PluginProvider>
+    )
+
+    expect(() => root.findByType(Foo)).toThrow()
+  })
+})

--- a/src/components/plugin-provider.js
+++ b/src/components/plugin-provider.js
@@ -18,6 +18,7 @@ const { Provider } = context
   alarms        - ( bg only ) a way to listen to heartbeat ticks
   model         - data structure for db
   constants     - constants variables defined in the extension
+  tabs          - ( ntp only ) some functions and state for tabs
 */
 
 export const PluginProvider = ({

--- a/src/components/plugin-provider.js
+++ b/src/components/plugin-provider.js
@@ -29,8 +29,11 @@ export const PluginProvider = ({
   constants,
   alarms,
   model,
+  children,
 }) => (
   <Provider
     value={{ env, extension, storage, config, constants, alarms, model }}
-  ></Provider>
+  >
+    {children}
+  </Provider>
 )

--- a/src/components/plugin-provider.js
+++ b/src/components/plugin-provider.js
@@ -30,9 +30,10 @@ export const PluginProvider = ({
   alarms,
   model,
   children,
+  tabs,
 }) => (
   <Provider
-    value={{ env, extension, storage, config, constants, alarms, model }}
+    value={{ env, extension, storage, config, constants, alarms, model, tabs }}
   >
     {children}
   </Provider>

--- a/src/components/tab.js
+++ b/src/components/tab.js
@@ -9,6 +9,7 @@ export const Tab = ({ name, children }) => {
   useEffect(() => {
     pushTab(name)
     return removeTab(name)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [name])
   // only supported on ntp page
   if (env !== 'ntp') return null

--- a/src/components/tab.js
+++ b/src/components/tab.js
@@ -7,6 +7,7 @@ export const Tab = ({ name, children }) => {
   const { pushTab, removeTab, currentTab } = tabs
 
   useEffect(() => {
+    if (env !== 'ntp') return () => {}
     pushTab(name)
     return removeTab(name)
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/src/components/tab.js
+++ b/src/components/tab.js
@@ -10,7 +10,7 @@ export const Tab = ({ name, children }) => {
     pushTab(name)
     return removeTab(name)
   }, [name])
-
+  // only supported on ntp page
   if (env !== 'ntp') return null
   if (name !== currentTab) return null
   return <Ingress target={constants.TABS_TARGET}>{children}</Ingress>

--- a/src/components/tab.js
+++ b/src/components/tab.js
@@ -3,8 +3,8 @@ import React, { useEffect, useContext } from 'react'
 import { context } from './plugin-provider'
 
 export const Tab = ({ name, children }) => {
-  const { constants, tabbing, env } = useContext(context)
-  const { pushTab, removeTab, currentTab } = tabbing
+  const { constants, tabs, env } = useContext(context)
+  const { pushTab, removeTab, currentTab } = tabs
 
   useEffect(() => {
     pushTab(name)

--- a/src/components/tab.js
+++ b/src/components/tab.js
@@ -1,0 +1,17 @@
+import { Ingress } from '@mujo/ingress'
+import React, { useEffect, useContext } from 'react'
+import { context } from './plugin-provider'
+
+export const Tab = ({ name, children }) => {
+  const { constants, tabbing, env } = useContext(context)
+  const { pushTab, removeTab, currentTab } = tabbing
+
+  useEffect(() => {
+    pushTab(name)
+    return removeTab(name)
+  }, [name])
+
+  if (env !== 'ntp') return null
+  if (name !== currentTab) return null
+  return <Ingress target={constants.TABS_TARGET}>{children}</Ingress>
+}

--- a/src/components/tab.test.js
+++ b/src/components/tab.test.js
@@ -1,0 +1,59 @@
+import { render } from '@testing-library/react'
+import React from 'react'
+import { PluginProvider } from './plugin-provider'
+import { Tab } from './Tab'
+
+jest.mock('@mujo/ingress')
+const { Ingress } = require('@mujo/ingress')
+
+describe('Tab component', () => {
+  test('Tab should not add a tab if it not the ntp env', () => {
+    const pushTab = jest.fn()
+    const removeTab = jest.fn()
+    render(
+      <PluginProvider env="background" tabs={{ pushTab }}>
+        <Tab />
+      </PluginProvider>
+    )
+    expect(pushTab).not.toBeCalled()
+    expect(removeTab).not.toBeCalled()
+  })
+
+  test('Tab should add a tab if it not the ntp env', () => {
+    const pushTab = jest.fn()
+    const removeTab = jest.fn()
+    const constants = { TABS_TARGET: 'foo' }
+    render(
+      <PluginProvider
+        env="ntp"
+        tabs={{ pushTab, removeTab, currentTab: 'foo' }}
+        constants={constants}
+      >
+        <Tab name="bar" />
+      </PluginProvider>
+    )
+    expect(pushTab).toBeCalled()
+    expect(removeTab).toBeCalled()
+  })
+
+  test('Tab should render children if the currentTab', async () => {
+    const pushTab = jest.fn()
+    const removeTab = jest.fn()
+    const constants = { TABS_TARGET: 'foo' }
+    const Foo = jest.fn().mockReturnValue(<>Foo</>)
+    Ingress.mockImplementation(({ children }) => <>{children}</>)
+    const { findByText } = render(
+      <PluginProvider
+        env="ntp"
+        tabs={{ pushTab, removeTab, currentTab: 'foo' }}
+        constants={constants}
+      >
+        <Tab name="foo">
+          <Foo />
+        </Tab>
+      </PluginProvider>
+    )
+
+    expect(findByText(/Foo/)).toBeTruthy()
+  })
+})

--- a/src/components/tab.test.js
+++ b/src/components/tab.test.js
@@ -1,9 +1,10 @@
 import { render } from '@testing-library/react'
 import React from 'react'
 import { PluginProvider } from './plugin-provider'
-import { Tab } from './Tab'
+import { Tab } from './tab'
 
 jest.mock('@mujo/ingress')
+// eslint-disable-next-line import-order-alphabetical/order
 const { Ingress } = require('@mujo/ingress')
 
 describe('Tab component', () => {

--- a/src/hooks/use-heart-beat.js
+++ b/src/hooks/use-heart-beat.js
@@ -1,5 +1,5 @@
 import { useEffect, useCallback, useContext } from 'react'
-import { context } from '../../components/plugin-provider'
+import { context } from '../components/plugin-provider'
 
 export const useHeartBeat = fn => {
   const { alarms, constants, isActive } = useContext(context)

--- a/src/index.js
+++ b/src/index.js
@@ -1,0 +1,2 @@
+export * from './components'
+export * from './hooks'

--- a/src/index.js
+++ b/src/index.js
@@ -1,2 +1,3 @@
+/* barrel files till we can find a easier pattern */
 export * from './components'
 export * from './hooks'


### PR DESCRIPTION
## Description

This adds a few top-level components that should only render when given a certain env variable. Essentially this allows me to pass `env` via context to these components and only render out certain environments.

for example

```javascript
...
<Background>
  <Log  value='foo' />
</Background>
...
````

In this example, if the Log component logs to the console then this log would only show up when the env is set to 'background'. Same with NewTabPage and Content.

## Other Changes

* some compilation fixes 
* version bumped  ( a few times, sorry this is messy )
* Also add a tab component to match the release of Mujo 1.6.0