### PR TITLE
use message hook

### DIFF
--- a/src/components/plugin-provider.js
+++ b/src/components/plugin-provider.js
@@ -10,16 +10,17 @@ const { Provider } = context
   extensions to allow the plugins to have access to common functionality
   within the app with out exposing it to window or something else gross
 
-  env           - the environment in the extension (background | content | ntp)
-  extension     - sugar sytax extension of browser api's
-  storage       - access to the database
-  config        - configuration for the extension
-  changeEmitter - ( bg only ) a way for storage updates to be propgated to hooks
-  alarms        - ( bg only ) a way to listen to heartbeat ticks
-  model         - data structure for db
-  constants     - constants variables defined in the extension
-  tabs          - ( ntp only ) some functions and state for tabs
-  settings      - ( ntp only ) some functions and state for settings
+  env            - the environment in the extension (background | content | ntp)
+  extension      - sugar sytax extension of browser api's
+  storage        - access to the database
+  config         - configuration for the extension
+  changeEmitter  - ( bg only ) storage updates propgated to hooks
+  messageEmitter - ( bg only ) event emmiter for messages
+  alarms         - ( bg only ) a way to listen to heartbeat ticks
+  model          - data structure for db
+  constants      - constants variables defined in the extension
+  tabs           - ( ntp only ) some functions and state for tabs
+  settings       - ( ntp only ) some functions and state for settings
 */
 
 export const PluginProvider = ({
@@ -28,6 +29,7 @@ export const PluginProvider = ({
   storage,
   config,
   changeEmitter,
+  messageEmitter,
   constants,
   alarms,
   model,
@@ -42,6 +44,7 @@ export const PluginProvider = ({
       storage,
       config,
       changeEmitter,
+      messageEmitter,
       constants,
       alarms,
       model,

--- a/src/hooks/index.js
+++ b/src/hooks/index.js
@@ -1,2 +1,3 @@
 export { useHeartBeat } from './use-heart-beat'
 export { useStorage } from './use-storage'
+export { useMessage } from './use-message'

--- a/src/hooks/use-message.js
+++ b/src/hooks/use-message.js
@@ -1,0 +1,17 @@
+import { useEffect, useCallback, useContext } from 'react'
+import { context } from '../components/plugin-provider'
+
+export const useMessage = fn => {
+  const { messageEmitter, constants } = useContext(context)
+  const { MESSAGE } = constants
+  const onMessage = useCallback(
+    async (...args) => {
+      fn(...args)
+    },
+    [fn]
+  )
+  useEffect(() => {
+    messageEmitter.on(MESSAGE, onMessage)
+    return () => messageEmitter.off(MESSAGE, onMessage)
+  }, [onMessage, messageEmitter, MESSAGE])
+}


### PR DESCRIPTION
## Description

This hook will allow for plugins to get access to all the background messages of the Chrome extension. Right now it is pretty exclusive to the background page but can easily be adapted for the content and ntp script.

example usage
```javascript
...
  useMessage(({ request, sender, sendResponse }) => {
    const { event } = request
    if (event === constants.PAGE_VIEWING_TIME) {
      updateScreenTime(sender.url, request.measure)
    }
  })
...
```